### PR TITLE
Adding library

### DIFF
--- a/windows/tests/test_format_handling.c
+++ b/windows/tests/test_format_handling.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <math.h>
 
 #ifndef M_PI

--- a/windows/userspace/virtual_sine_device.c
+++ b/windows/userspace/virtual_sine_device.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <math.h>
 #include <signal.h>
 


### PR DESCRIPTION
Adding stdlib.h library to file test_format_handling.c and virtual_sine_device.c for windows to enable the use of int32_t and int16_t used by copilot. 